### PR TITLE
Add link to OWASP Slack

### DIFF
--- a/info.md
+++ b/info.md
@@ -3,4 +3,5 @@
 
 ### Social Links
 * [Meetup](https://www.meetup.com/owasp-cincinnati-meetup-group/)
+* [OWASP Slack](https://owasp.org/slack/invite) (#chapter-cincinnati)
 


### PR DESCRIPTION
Now that we have a channel on the OWASP slack (#chapter-cincinnati), let's add a link to it in our GitHub repository.