### PR TITLE
Update link name for GitHub repository link

### DIFF
--- a/info.md
+++ b/info.md
@@ -6,4 +6,4 @@
 * [OWASP Slack](https://owasp.org/slack/invite) (#chapter-cincinnati)
 
 ### Code Repository
-* [repo](https://github.com/OWASP/www-chapter-cincinnati)
+* [GitHub Repository](https://github.com/OWASP/www-chapter-cincinnati)


### PR DESCRIPTION
- Updated name of the repository link in the information sidebar from `repo` to `GitHub Repository`